### PR TITLE
Fix valid response in jwt errors

### DIFF
--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -109,7 +109,7 @@ sub vcl_backend_response {
 
 sub vcl_synth {
     set resp.http.Content-Type = "application/json";
-    synthetic( {"{ "code":"} + resp.status + {" "message": ""} + resp.reason + {"" }"} );
+    synthetic( {"{ "code":"} + resp.status + {", "message": ""} + resp.reason + {"" }"} );
 
     return (deliver);
 }


### PR DESCRIPTION
Varnish returns a malformed json in errors:

{ "code":401 "message": "Invalid JWT Token: Token is not a JWT: token" }

instead of

{ "code":401, "message": "Invalid JWT Token: Token is not a JWT: token" }