### PR TITLE
FIX CORS in a non valid jwt request.

### DIFF
--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -109,6 +109,9 @@ sub vcl_backend_response {
 
 sub vcl_synth {
     set resp.http.Content-Type = "application/json";
+    set resp.http.Access-Control-Allow-Origin = "*";
+    set resp.http.Access-Control-Allow-Credentials = "true";
+    
     synthetic( {"{ "code":"} + resp.status + {", "message": ""} + resp.reason + {"" }"} );
 
     return (deliver);


### PR DESCRIPTION
When we do a request with a expired jwt token, varnish returns a response without CORS header