### PR TITLE
Fix invalid token response when request is restart

### DIFF
--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -48,6 +48,7 @@ sub vcl_recv {
       set req.http.tmpPayload = regsub(req.http.x-token,"[^\.]+\.([^\.]+)\.[^\.]+$","\1");
       set req.http.tmpRequestSig = regsub(req.http.x-token,"^[^\.]+\.[^\.]+\.([^\.]+)$","\1");
 
+      v.reset();  // need this if request restart
       v.update(req.http.tmpHeader + "." + req.http.tmpPayload );
 
 


### PR DESCRIPTION
Issue when request is restart

https://github.com/opositatest/varnish-jwt/issues/7#issuecomment-691118365

Steps to reproduce:

Add the following code in default.vlc

```
      if (! v.valid( blob.decode(BASE64URLNOPAD, encoded=req.http.tmpRequestSig))) {
          return (synth(401, "Invalid JWT Token: Signature"));
      }

      if (req.restarts < 3) {
        return (restart);
      }

      set req.http.X-Expiration = regsub(digest.base64_decode(req.http.tmpPayload), {"^.*?"exp":([0-9]+).*?$"},"\1");
```

When varnish restart the request and call to v.update function:

```
sut_1    | **** c1   http[ 1] |401
sut_1    | **** c1   http[ 2] |Invalid JWT Token: Signature
sut_1    | **** c1   http[ 3] |Date: Fri, 02 Oct 2020 14:30:55 GMT
sut_1    | **** c1   http[ 4] |Server: Varnish
sut_1    | **** c1   http[ 5] |X-Varnish: 1002
sut_1    | **** c1   http[ 6] |Content-Type: application/json
sut_1    | **** c1   http[ 7] |Access-Control-Allow-Origin: *
sut_1    | **** c1   http[ 8] |Access-Control-Allow-Credentials: true
sut_1    | **** c1   http[ 9] |Content-Length: 57
sut_1    | **** c1   http[10] |Connection: keep-alive
sut_1    | **** c1   c-l|{ "code":401, "message": "Invalid JWT Token: Signature" }
sut_1    | **** c1   bodylen = 57
sut_1    | **   c1   === expect resp.status == 200
sut_1    | ---- c1   EXPECT resp.status (401) == "200" failed
```




