### PR TITLE
fix: pass request to backend if no authorization header is set

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,9 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
   
     - name: Build
-      run: docker-compose -f docker-compose.test.yml build
+      run: docker compose -f docker-compose.test.yml build
     - name: Run test
-      run: docker-compose -f docker-compose.test.yml up --abort-on-container-exit
+      run: docker compose -f docker-compose.test.yml up --abort-on-container-exit
 
     - name: Get the version
       id: get_version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,6 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - name: Build
-      run: docker-compose -f docker-compose.test.yml build
+      run: docker compose -f docker-compose.test.yml build
     - name: Run test
-      run: docker-compose -f docker-compose.test.yml up --abort-on-container-exit
+      run: docker compose -f docker-compose.test.yml up --abort-on-container-exit

--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -34,6 +34,10 @@ sub vcl_recv {
     return (pass);
   }
 
+  if(!req.http.Authorization) {
+    return (pass);
+  }
+
   if(req.http.Authorization && req.http.Authorization ~ "Bearer") {
       set req.http.x-token =  regsuball(req.http.Authorization, "Bearer ", "");
 


### PR DESCRIPTION
In default vcl, pass request to backend if no authorization header is set.

Also replace docker-compose by docker compose as announced here: https://github.com/actions/runner-images/issues/9692